### PR TITLE
GCS and bug fixes with schema generation and data coercion

### DIFF
--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -46,9 +46,9 @@ def discover(config):
         try:
             modified_since = dateutil.parser.parse(table_spec['start_date'])
             target_files = file_utils.get_matching_objects(table_spec, modified_since)
-            sample_rate = table_spec.get('sample_rate',10)
+            sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)
-            max_sampled_files = table_spec.get('max_sampled_files', 5)
+            max_sampled_files = table_spec.get('max_sampled_files', 50)
             prefer_number_vs_integer = table_spec.get('prefer_number_vs_integer', False)
             samples = file_utils.sample_files(table_spec, target_files,sample_rate=sample_rate,
                                               max_records=max_sampling_read, max_files=max_sampled_files)

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import dateutil
 import requests
 import singer
+from singer.transform import Transformer
 import boto3
 from google.cloud import storage
 import os, logging
@@ -22,27 +23,29 @@ def write_file(target_filename, table_spec, schema, max_records=-1):
     target_uri = table_spec['path'] + '/' + target_filename
     records_synced = 0
     try:
-        iterator = tap_spreadsheets_anywhere.format_handler.get_row_iterator(table_spec, target_uri)
-        for row in iterator:
-            metadata = {
-                '_smart_source_bucket': table_spec['path'],
-                '_smart_source_file': target_filename,
-                # index zero, +1 for header row
-                '_smart_source_lineno': records_synced + 2
-            }
+        with Transformer() as transformer:
+            iterator = tap_spreadsheets_anywhere.format_handler.get_row_iterator(table_spec, target_uri)
+            for row in iterator:
+                metadata = {
+                    '_smart_source_bucket': table_spec['path'],
+                    '_smart_source_file': target_filename,
+                    # index zero, +1 for header row
+                    '_smart_source_lineno': records_synced + 2
+                }
 
-            try:
-                to_write = [{**conversion.convert_row(row, schema), **metadata}]
-                singer.write_records(table_spec['name'], to_write)
-            except BrokenPipeError as bpe:
-                LOGGER.error(
-                    f'Pipe to loader broke after {records_synced} records were written from {target_filename}: troubled '
-                    f'line was {to_write[0]}')
-                raise bpe
+                try:
+                    record = conversion.convert_row(row, schema)
+                    transformed_record = transformer.transform(record, schema, metadata)
+                    singer.write_record(table_spec['name'], transformed_record)
+                except BrokenPipeError as bpe:
+                    LOGGER.error(
+                        f'Pipe to loader broke after {records_synced} records were written from {target_filename}: troubled '
+                        f'line was {record}')
+                    raise bpe
 
-            records_synced += 1
-            if 0 < max_records <= records_synced:
-                break
+                records_synced += 1
+                if 0 < max_records <= records_synced:
+                    break
 
     except tap_spreadsheets_anywhere.format_handler.InvalidFormatError as ife:
         if table_spec.get('invalid_format_action','fail').lower() == "ignore":

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -214,9 +214,11 @@ def list_files_in_gs_bucket(bucket, search_prefix=None):
         
     blobs = gs_client.list_blobs(bucket, prefix=search_prefix)
 
-    LOGGER.info("Found {} files.".format(len(blobs)))
+    target_objects = [{'Key': blob.name, 'LastModified': blob.updated} for blob in blobs]
+    
+    LOGGER.info("Found {} files.".format(len(target_objects)))
 
-    return [{'Key': blob.name, 'LastModified': blob.updated} for blob in blobs]
+    return target_objects
 
 
 def list_files_in_s3_bucket(bucket, search_prefix=None):


### PR DESCRIPTION
* Fixes an error in getting GCS objects where the logger was attempting to call `len()` on an iterator. 
* Refactors write records to use Singer's Transformer() option for schema validation.
* Fixes bug where the original schema was being overwritten during `conversion.convert_row()` causing schema properties to no longer allow `null` values.
* Fixes bug where a blank string containing a space was not counting as `None`.