### PR TITLE
Support nested JSON arrays - Fixes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Each object in the 'tables' array describes one or more CSV or Excel spreadsheet
 - **worksheet_name**: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
 - **delimiter**: (optional) the delimiter to use when format is 'csv'. Defaults to a comma ',' but you can set delimiter to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter. 
 - **quotechar**: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"'
+- **json_path**: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 
 ### Automatic Config Generation
 

--- a/tap_spreadsheets_anywhere/configuration.py
+++ b/tap_spreadsheets_anywhere/configuration.py
@@ -21,6 +21,7 @@ CONFIG_CONTRACT = Schema({
         Optional('worksheet_name'): str,
         Optional('delimiter'): str,
         Optional('quotechar'): str,
+        Optional('json_path'): str,
         Optional('sample_rate'): int,
         Optional('max_sampling_read'): int,
         Optional('max_records_per_run'): int,

--- a/tap_spreadsheets_anywhere/json_handler.py
+++ b/tap_spreadsheets_anywhere/json_handler.py
@@ -24,6 +24,10 @@ def generator_wrapper(root_iterator):
 def get_row_iterator(table_spec, reader):
     try:
         json_array = json.load(reader)
+        json_path = table_spec.get('json_path', None)
+        if json_path is not None:
+            json_array = json_array[json_path]
+
         # throw a TypeError if the root json object can not be iterated
         return generator_wrapper(iter(json_array))
     except JSONDecodeError as jde:

--- a/tap_spreadsheets_anywhere/test/test_json.py
+++ b/tap_spreadsheets_anywhere/test/test_json.py
@@ -22,6 +22,15 @@ TEST_TABLE_SPEC = {
             "start_date": "2017-05-01T00:00:00Z",
             "key_properties": [],
             "format": "detect"
+        },
+        {
+            "path": "file://./tap_spreadsheets_anywhere/test",
+            "name": "nestedlist",
+            "pattern": ".*\\.json",
+            "start_date": "2017-05-01T00:00:00Z",
+            "key_properties": [],
+            "json_path": "someKey",
+            "format": "detect"
         }
     ]
 }
@@ -37,5 +46,8 @@ class TestFormatHandler(unittest.TestCase):
         reader = StringIO('{"k":"v"}\n{"k":"v"}\n{"k":"v"}')
         json_handler.get_row_iterator(TEST_TABLE_SPEC['tables'][0], reader)
 
-
-
+    def test_json_nested_array(self):
+        reader = StringIO('{"someKey": [{"k":"v"},{"k":"v"},{"k":"v"}]}')
+        iterator = json_handler.get_row_iterator(TEST_TABLE_SPEC['tables'][2], reader)
+        for row in iterator:
+            self.assertEqual(row['k'], 'v')


### PR DESCRIPTION
This PR adds support for JSON arrays nested under a single key from the top level of the JSON file. The default value of the new config setting does not modify the current behaviour.
See #16 

@ets As mentioned in the issue, this works for me, but I think it would be nice to improve on this to handle multiple levels of nesting. Maybe I'll add a new PR when I actually need that :)