### PR TITLE
Speed up schema deepcopy

### DIFF
--- a/tap_spreadsheets_anywhere/conversion.py
+++ b/tap_spreadsheets_anywhere/conversion.py
@@ -1,13 +1,13 @@
 import dateutil
 import pytz
 import logging
-from copy import deepcopy
+import pickle
 
 LOGGER = logging.getLogger(__name__)
 
 
 def convert_row(row, schema):
-    t_schema = deepcopy(schema)
+    t_schema = pickle.loads(pickle.dumps((schema))
     to_return = {}
     for key, value in row.items():
         if key in t_schema['properties']:


### PR DESCRIPTION
When running the tap, the first line in `convert_row` spends about 0.1ms/row running `deepcopy`. Replacing it with `pickle` dumps/loads divides this time by about 10. Overall, this reduces the tap's runtime by about 20% on the examples I have.

This `deepcopy` was introduced in https://github.com/ets/tap-spreadsheets-anywhere/pull/7/commits/2fd47eb5a4bfedb58e2c4e10e48e407763adef4d I suspect it might be possible to do away with the schema duplication for each row, by duplicating once just before https://github.com/ets/tap-spreadsheets-anywhere/blob/84f6b8e9b755e73d515be9a17258ceb01494001b/tap_spreadsheets_anywhere/file_utils.py#L41 but I'm not entirely sure about the problem described in that commit. @CoopTang do you have an example of input to reproduce the problem you had, so that I don't introduce a regression by trying to speed things up?