### PR TITLE
Add Paramiko (missing for ssh, scp, sftp)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         'boto3>=1.15.5',
         'google-cloud-storage>=1.31.2',
         'openpyxl',
-        'xlrd'
+        'xlrd',
+        'paramiko'
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
Description: If you use a path that has ssh, scp, or sftp (e.g. `- path: 'sftp://`), we get the following error: `paramiko missing` from https://github.com/ets/tap-spreadsheets-anywhere/blob/96b8ded638f5c78700c7e300303b4b5a6c778d60/tap_spreadsheets_anywhere/file_utils.py#L162-L169

Changes: Add paramiko to setup.py