### PR TITLE
Support for Azure Storage accounts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
         'protobuf>=4.21.12',
         'openpyxl',
         'xlrd',
-        'paramiko'
+        'paramiko',
+        'azure-storage-blob>=12.14.0'
     ],
     entry_points="""
     [console_scripts]

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -115,7 +115,6 @@ def parse_path(path):
 
 def get_matching_objects(table_spec, modified_since=None):
     protocol, bucket = parse_path(table_spec['path'])
-    LOGGER.info(f"Getting protocol {protocol} and bucket {bucket} from {table_spec['path']}")
 
     # TODO Breakout the transport schemes here similar to the registry/loading pattern used by smart_open
     if protocol == 's3':
@@ -131,7 +130,7 @@ def get_matching_objects(table_spec, modified_since=None):
     elif protocol in ["azure"]:
         target_objects = list_files_in_azure_bucket(bucket,table_spec.get('search_prefix'))
     else:
-        raise ValueError("Protocol {} (possibly azure) not yet supported. Pull Requests are welcome!")
+        raise ValueError("Protocol {} not yet supported. Pull Requests are welcome!")
 
     pattern = table_spec['pattern']
     matcher = re.compile(pattern)

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -131,7 +131,7 @@ def get_matching_objects(table_spec, modified_since=None):
     elif protocol in ["azure"]:
         target_objects = list_files_in_azure_bucket(bucket,table_spec.get('search_prefix'))
     else:
-        raise ValueError("Protocol {} not yet supported. Pull Requests are welcome!")
+        raise ValueError("Protocol {} (possibly azure) not yet supported. Pull Requests are welcome!")
 
     pattern = table_spec['pattern']
     matcher = re.compile(pattern)

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -115,6 +115,7 @@ def parse_path(path):
 
 def get_matching_objects(table_spec, modified_since=None):
     protocol, bucket = parse_path(table_spec['path'])
+    LOGGER.info(f"Getting protocol {protocol} and bucket {bucket} from {table_spec['path']}")
 
     # TODO Breakout the transport schemes here similar to the registry/loading pattern used by smart_open
     if protocol == 's3':

--- a/tap_spreadsheets_anywhere/format_handler.py
+++ b/tap_spreadsheets_anywhere/format_handler.py
@@ -38,20 +38,6 @@ def get_streamreader(uri, universal_newlines=True,newline='',open_mode='r'):
         return monkey_patch_streamreader(streamreader)
     return streamreader
 
-    # if uri.startswith('azure://'):
-    #     connect_str = os.environ['AZURE_STORAGE_CONNECTION_STRING']
-    #     transport_params = {
-    #         'client': BlobServiceClient.from_connection_string(connect_str),
-    #     }
-    #     streamreader = smart_open.open(uri, open_mode, newline=newline, errors='surrogateescape', 
-    #                     transport_params=transport_params)
-    #     return streamreader
-
-    # streamreader = smart_open.open(uri, open_mode, newline=newline, errors='surrogateescape')
-    # if not universal_newlines and isinstance(streamreader, StreamReader):
-    #     return monkey_patch_streamreader(streamreader)
-    # return streamreader
-
 
 def monkey_patch_streamreader(streamreader):
     streamreader.mp_newline = '\n'

--- a/tap_spreadsheets_anywhere/format_handler.py
+++ b/tap_spreadsheets_anywhere/format_handler.py
@@ -5,7 +5,7 @@ import tap_spreadsheets_anywhere.csv_handler
 import tap_spreadsheets_anywhere.excel_handler
 import tap_spreadsheets_anywhere.json_handler
 import tap_spreadsheets_anywhere.jsonl_handler
-
+from azure.storage.blob import BlobServiceClient
 
 class InvalidFormatError(Exception):
     def __init__(self, fname, message="The file was not in the expected format"):
@@ -18,6 +18,15 @@ class InvalidFormatError(Exception):
 
 
 def get_streamreader(uri, universal_newlines=True,newline='',open_mode='r'):
+    if uri.startswith('azure://'):
+        connect_str = os.environ['AZURE_STORAGE_CONNECTION_STRING']
+        transport_params = {
+            'client': BlobServiceClient.from_connection_string(connect_str),
+        }
+        streamreader = smart_open.open(uri, open_mode, newline=newline, errors='surrogateescape', 
+                        transport_params=transport_params)
+        return streamreader
+
     streamreader = smart_open.open(uri, open_mode, newline=newline, errors='surrogateescape')
     if not universal_newlines and isinstance(streamreader, StreamReader):
         return monkey_patch_streamreader(streamreader)

--- a/tap_spreadsheets_anywhere/format_handler.py
+++ b/tap_spreadsheets_anywhere/format_handler.py
@@ -6,6 +6,7 @@ import tap_spreadsheets_anywhere.excel_handler
 import tap_spreadsheets_anywhere.json_handler
 import tap_spreadsheets_anywhere.jsonl_handler
 from azure.storage.blob import BlobServiceClient
+import os
 
 class InvalidFormatError(Exception):
     def __init__(self, fname, message="The file was not in the expected format"):


### PR DESCRIPTION
Mostly as discussed in https://github.com/ets/tap-spreadsheets-anywhere/issues/31, basic support for Azure storage blobs.

Two issues that came up, that probably aren't blockers to merging, but that I'll keep mulling over:

1. The function that connects to Azure doesn't have access to the config (it just gets passed the file location etc), which means I don't see how we can add the azure key to the config and so the connection string must simply be present as an env variable, not a config.

2. I could not find any natural place to add documentation for this. There is no place (that I can find) where idiosyncrasies about specific sources are documented.