### PR TITLE
Discovery should fail when there's an error

### DIFF
--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -88,7 +88,8 @@ def discover(config):
                 )
             )
         except Exception as err:
-            LOGGER.error(f"Unable to write Catalog entry for '{table_spec['name']}' - it will be skipped due to error {err}")
+            LOGGER.error(f"Unable to write Catalog entry for '{table_spec['name']}' - it will be skipped due too error {err}")
+            exit(1)
 
     return Catalog(streams)
 

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -89,7 +89,7 @@ def discover(config):
             )
         except Exception as err:
             LOGGER.error(f"Unable to write Catalog entry for '{table_spec['name']}' - it will be skipped due too error {err}")
-            exit(1)
+            raise err
 
     return Catalog(streams)
 

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -88,7 +88,7 @@ def discover(config):
                 )
             )
         except Exception as err:
-            LOGGER.error(f"Unable to write Catalog entry for '{table_spec['name']}' - it will be skipped due too error {err}")
+            LOGGER.error(f"Unable to write Catalog entry for '{table_spec['name']}' - it will be skipped due to error {err}")
             raise err
 
     return Catalog(streams)


### PR DESCRIPTION
Closes #45 


This could break folks who rely on errors being auto ignored. Do we want a config flag? 