### PR TITLE
Fix `zipfile.BadZipFile` error when reading `.xlsx` files.

### DIFF
--- a/tap_spreadsheets_anywhere/excel_handler.py
+++ b/tap_spreadsheets_anywhere/excel_handler.py
@@ -62,7 +62,7 @@ def get_legacy_row_iterator(table_spec, file_handle):
 
 
 def get_row_iterator(table_spec, file_handle):
-    workbook = openpyxl.load_workbook(file_handle, read_only=True)
+    workbook = openpyxl.load_workbook(file_handle.name, read_only=True)
     
     if "worksheet_name" in table_spec:
         try:


### PR DESCRIPTION
Use the name of the `.xlsx`, when opening the workbook, since the following error is thrown when attempting to read the `io.TextIOWrapper` instance:

`zipfile.BadZipFile: File is not a zip file when loading an .xlsx file`

Fixes #54.