### PR TITLE
Fix SFTP access/read to excel files

### DIFF
--- a/tap_spreadsheets_anywhere/excel_handler.py
+++ b/tap_spreadsheets_anywhere/excel_handler.py
@@ -69,7 +69,7 @@ def get_legacy_row_iterator(table_spec, file_handle):
 
 
 def get_row_iterator(table_spec, file_handle):
-    workbook = openpyxl.load_workbook(file_handle.name, read_only=True)
+    workbook = openpyxl.load_workbook(file_handle, read_only=True)
     
     if "worksheet_name" in table_spec:
         try:

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -181,7 +181,7 @@ def list_files_in_SSH_bucket(uri, search_prefix=None):
     parsed_uri = ssh_transport.parse_uri(uri)
     uri_path = parsed_uri.pop('uri_path')
     transport_params={'connect_kwargs':{'allow_agent':False,'look_for_keys':False}}
-    ssh = ssh_transport._connect(parsed_uri['host'], parsed_uri['user'], parsed_uri['port'], parsed_uri['password'], transport_params=transport_params)
+    ssh = ssh_transport._connect_ssh(parsed_uri['host'], parsed_uri['user'], parsed_uri['port'], parsed_uri['password'], transport_params=transport_params)
     sftp_client = ssh.get_transport().open_sftp_client()
     entries = []
     max_results = 10000


### PR DESCRIPTION
This commit addresses two issues:
- `smart_open` private function was renamed to `_connect_ssh`
  - Seems like this change was made 2y ago: [smart_open](https://github.com/piskvorky/smart_open/commit/1cfe4acc8ed350564944aca2ca768b9b4448fd73#diff-1b55cd86bb864b8fa6eeaee99db0852f47c504fef2875010c9cb70043e80b426R81)
- `openpyxl.load_workbook` pass file handle instead of name
  - [There seems to be another PR that addresses this same issue](https://github.com/ets/tap-spreadsheets-anywhere/pull/56)