### PR TITLE
Update _connect_ssh parameters for smart_open compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     py_modules=["tap_spreadsheets_anywhere"],
     install_requires=[
         "singer-python>=5.0.12",
-        'smart_open>=2.1',
+        'smart_open>=7.2.0',
         'voluptuous>=0.10.5',
         'boto3>=1.15.5',
         'google-cloud-storage>=2.7.0',

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -181,7 +181,7 @@ def list_files_in_SSH_bucket(uri, search_prefix=None):
     parsed_uri = ssh_transport.parse_uri(uri)
     uri_path = parsed_uri.pop('uri_path')
     transport_params={'connect_kwargs':{'allow_agent':False,'look_for_keys':False}}
-    ssh = ssh_transport._connect_ssh(parsed_uri['host'], parsed_uri['user'], parsed_uri['port'], parsed_uri['password'], transport_params=transport_params)
+    ssh = ssh_transport._connect_ssh(parsed_uri['host'], parsed_uri['user'], parsed_uri['port'], parsed_uri['password'], transport_params.get('connect_kwargs'))
     sftp_client = ssh.get_transport().open_sftp_client()
     entries = []
     max_results = 10000


### PR DESCRIPTION
Adjust the last parameter of the `_connect_ssh` function to align with changes introduced in the smart_open package version 7.2.0. Update the installation requirement for smart_open accordingly.