### PR TITLE
Fix typo in requirements in setup.py that prevents install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(
         'paramiko',
         'azure-storage-blob>=12.14.0',
         'jsonpath-ng>=1.5.3',
-        'pyarrow>=5.0.0',
-        'importlib-metadata>=6,<8'
+        'pyarrow>=5.0.0'
     ],
     packages=["tap_spreadsheets_anywhere"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'paramiko',
         'azure-storage-blob>=12.14.0',
         'jsonpath-ng>=1.5.3',
-        'pyarrow>=5.0.0'
+        'pyarrow>=5.0.0',
+        'importlib-metadata>=6.8'
     ],
     packages=["tap_spreadsheets_anywhere"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'paramiko',
         'azure-storage-blob>=12.14.0',
         'jsonpath-ng>=1.5.3',
-        'pyarrow>=5.0.0'
+        'pyarrow>=5.0.0',
+        'importlib-metadata>=6,<8'
     ],
     packages=["tap_spreadsheets_anywhere"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'azure-storage-blob>=12.14.0',
         'jsonpath-ng>=1.5.3',
         'pyarrow>=5.0.0',
-        'importlib-metadata>=6.8'
+        'importlib-metadata>=6,<8'
     ],
     packages=["tap_spreadsheets_anywhere"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'xlrd',
         'paramiko',
         'azure-storage-blob>=12.14.0',
-        'jsonpath-ng>=1.5.3'
+        'jsonpath-ng>=1.5.3',
         'pyarrow>=5.0.0'
     ],
     packages=["tap_spreadsheets_anywhere"],


### PR DESCRIPTION
A missing comma is preventing the tap from being installed and issues in recent dependency releases are preventing catalogue discovery. 